### PR TITLE
ActiveStorage 画像アップロードを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,7 @@ DEPENDENCIES
   erb_lint
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction avatar]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.order(:id).page(params[:page]).includes(:avatar_attachment)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one_attached :avatar
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,8 @@
   <%= f.label :self_introduction %>
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="field">
+  <%= f.label :avatar %>
+  <%= f.file_field :avatar %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
   </thead>
 
   <tbody>
-    <% @users.eager_load(:avatar_attachment).each do |user| %>
+    <% @users.includes(:avatar_attachment).each do |user| %>
       <tr>
         <td><%= image_tag user.avatar.variant(resize: '100x100').processed if user.avatar.attached? %></td>
         <td><%= user.email %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= User.human_attribute_name(:avatar) %></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
@@ -12,8 +13,9 @@
   </thead>
 
   <tbody>
-    <% @users.each do |user| %>
+    <% @users.eager_load(:avatar_attachment).each do |user| %>
       <tr>
+        <td><%= image_tag user.avatar.variant(resize: '100x100').processed if user.avatar.attached? %></td>
         <td><%= user.email %></td>
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
   </thead>
 
   <tbody>
-    <% @users.includes(:avatar_attachment).each do |user| %>
+    <% @users.each do |user| %>
       <tr>
         <td><%= image_tag user.avatar.variant(resize: '100x100').processed if user.avatar.attached? %></td>
         <td><%= user.email %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,11 @@
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
 <p>
+  <strong><%= User.human_attribute_name(:avatar) %>:</strong>
+  <%= image_tag @user.avatar.variant(resize: '300x300').processed if @user.avatar.attached? %>
+</p>
+
+<p>
   <strong><%= User.human_attribute_name(:email) %>:</strong>
   <%= @user.email %>
 </p>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        avatar: プロフィール画像

--- a/db/migrate/20221024091050_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20221024091050_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_10_24_091050) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -37,4 +65,6 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 概要
ActiveStorageを使ってユーザー情報にプロフィール画像を追加する
- アカウント登録時にプロフィール画像を登録
- ユーザー一覧画面で画像を確認
- ユーザー詳細画面で画像を確認

## 実装後の画面確認
### <ユーザー一覧画面> 画像サイズ100×100
↓
<img width="657" alt="Screen Shot 2022-11-01 at 18 57 02" src="https://user-images.githubusercontent.com/80469652/199211106-12a88c70-686c-433a-b9d7-77017ba94d1a.png">

### <ユーザー詳細画面> 画像サイズ300×300
↓
<img width="563" alt="Screen Shot 2022-11-01 at 18 57 12" src="https://user-images.githubusercontent.com/80469652/199211355-9239bfa9-78d5-48a3-89b0-998ce0d5e208.png">
